### PR TITLE
Prepare release 0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ai.finity</groupId>
 	<artifactId>aws-java-sdk-awis</artifactId>
 	<packaging>jar</packaging>
-	<version>0.2</version>
+	<version>0.3</version>
 
 	<name>aws-java-sdk-awis</name>
 	<description>Amazon Alexa Web Information Service client</description>


### PR DESCRIPTION
Change the implementation so the client needs to be initialized only once and can be reused to make requests concurrently.

For that purpose, the V4 signature logic (ahem blindly copy/pasted from AWS code) don’t use instance variables to store the date when the client was initialized. Instead, the date is taken when a request is issued.

Also slightly refactored the code to follow some Java best practices. Most of them were suggested by an IDE though.